### PR TITLE
feat(python): Add crypto utilities and keystore system

### DIFF
--- a/python/src/indexedcp/__init__.py
+++ b/python/src/indexedcp/__init__.py
@@ -7,6 +7,8 @@ from .logger import create_logger
 from .storage import BaseStorage, SQLiteStorage, create_storage
 from .client import IndexedCPClient
 from .server import IndexedCPServer
+from .crypto_utils import CryptoUtils
+from .keystores import BaseKeyStore, FileSystemKeyStore, create_keystore
 
 __version__ = "0.1.0"
 __all__ = [
@@ -15,5 +17,9 @@ __all__ = [
     "SQLiteStorage",
     "create_storage",
     "IndexedCPClient",
-    "IndexedCPServer"
+    "IndexedCPServer",
+    "CryptoUtils",
+    "BaseKeyStore",
+    "FileSystemKeyStore",
+    "create_keystore"
 ]

--- a/python/src/indexedcp/crypto_utils.py
+++ b/python/src/indexedcp/crypto_utils.py
@@ -1,0 +1,298 @@
+"""
+Cryptographic utilities for asymmetric envelope encryption
+
+Design:
+- RSA-OAEP (SHA-256) for key wrapping
+- AES-256-GCM for data encryption
+- Per-stream ephemeral session keys
+- IV + AAD for authenticity and uniqueness
+"""
+
+import os
+import json
+import hashlib
+import base64
+from typing import Dict, Any, Tuple
+
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa, padding
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+from cryptography.hazmat.backends import default_backend
+
+
+class CryptoUtils:
+    """Cryptographic utilities for asymmetric envelope encryption."""
+    
+    def __init__(self):
+        self.AES_KEY_LENGTH = 32  # 256 bits
+        self.IV_LENGTH = 12  # 96 bits for GCM
+        self.AUTH_TAG_LENGTH = 16  # 128 bits
+    
+    def generate_server_key_pair(self, modulus_length: int = 4096) -> Dict[str, str]:
+        """
+        Generate RSA key pair for server.
+        
+        Args:
+            modulus_length: Key size in bits (default: 4096)
+        
+        Returns:
+            Dict containing publicKey, privateKey (PEM format), and kid (key ID)
+        """
+        # Generate RSA key pair
+        private_key = rsa.generate_private_key(
+            public_exponent=65537,
+            key_size=modulus_length,
+            backend=default_backend()
+        )
+        
+        # Serialize public key to PEM format
+        public_key_pem = private_key.public_key().public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo
+        ).decode('utf-8')
+        
+        # Serialize private key to PEM format
+        private_key_pem = private_key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption()
+        ).decode('utf-8')
+        
+        # Generate key ID from public key hash
+        kid = hashlib.sha256(public_key_pem.encode()).hexdigest()[:16]
+        
+        return {
+            'publicKey': public_key_pem,
+            'privateKey': private_key_pem,
+            'kid': kid
+        }
+    
+    def generate_session_key(self) -> bytes:
+        """
+        Generate ephemeral AES session key.
+        
+        Returns:
+            256-bit AES key as bytes
+        """
+        return os.urandom(self.AES_KEY_LENGTH)
+    
+    def wrap_session_key(self, session_key: bytes, public_key_pem: str) -> bytes:
+        """
+        Wrap (encrypt) an AES session key with RSA public key.
+        
+        Args:
+            session_key: AES key to wrap
+            public_key_pem: RSA public key in PEM format
+        
+        Returns:
+            Wrapped (encrypted) session key as bytes
+        """
+        # Load public key
+        public_key = serialization.load_pem_public_key(
+            public_key_pem.encode(),
+            backend=default_backend()
+        )
+        
+        # Encrypt session key with RSA-OAEP
+        wrapped_key = public_key.encrypt(
+            session_key,
+            padding.OAEP(
+                mgf=padding.MGF1(algorithm=hashes.SHA256()),
+                algorithm=hashes.SHA256(),
+                label=None
+            )
+        )
+        
+        return wrapped_key
+    
+    def unwrap_session_key(self, wrapped_key: bytes, private_key_pem: str) -> bytes:
+        """
+        Unwrap (decrypt) an AES session key with RSA private key.
+        
+        Args:
+            wrapped_key: Encrypted session key
+            private_key_pem: RSA private key in PEM format
+        
+        Returns:
+            Unwrapped AES session key as bytes
+        """
+        # Load private key
+        private_key = serialization.load_pem_private_key(
+            private_key_pem.encode(),
+            password=None,
+            backend=default_backend()
+        )
+        
+        # Decrypt session key with RSA-OAEP
+        session_key = private_key.decrypt(
+            wrapped_key,
+            padding.OAEP(
+                mgf=padding.MGF1(algorithm=hashes.SHA256()),
+                algorithm=hashes.SHA256(),
+                label=None
+            )
+        )
+        
+        return session_key
+    
+    def encrypt_packet(
+        self, 
+        data: bytes, 
+        session_key: bytes, 
+        metadata: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """
+        Encrypt data with AES-GCM.
+        
+        Args:
+            data: Plaintext to encrypt
+            session_key: AES session key
+            metadata: Additional authenticated data (sessionId, seq, etc.)
+        
+        Returns:
+            Dict containing ciphertext, iv, authTag, and aad
+        """
+        # Generate unique IV for this packet
+        iv = os.urandom(self.IV_LENGTH)
+        
+        # Prepare AAD (Additional Authenticated Data)
+        aad_dict = {
+            'sessionId': metadata.get('sessionId'),
+            'seq': metadata.get('seq'),
+            'codec': metadata.get('codec', 'raw'),
+            'timestamp': metadata.get('timestamp', int(time.time() * 1000))
+        }
+        aad = json.dumps(aad_dict, separators=(',', ':')).encode()
+        
+        # Create cipher
+        cipher = Cipher(
+            algorithms.AES(session_key),
+            modes.GCM(iv),
+            backend=default_backend()
+        )
+        encryptor = cipher.encryptor()
+        
+        # Set AAD
+        encryptor.authenticate_additional_data(aad)
+        
+        # Encrypt
+        ciphertext = encryptor.update(data) + encryptor.finalize()
+        
+        # Get authentication tag
+        auth_tag = encryptor.tag
+        
+        return {
+            'ciphertext': ciphertext,
+            'iv': iv,
+            'authTag': auth_tag,
+            'aad': aad
+        }
+    
+    def decrypt_packet(
+        self,
+        ciphertext: bytes,
+        session_key: bytes,
+        iv: bytes,
+        auth_tag: bytes,
+        aad: bytes
+    ) -> bytes:
+        """
+        Decrypt data with AES-GCM.
+        
+        Args:
+            ciphertext: Encrypted data
+            session_key: AES session key
+            iv: Initialization vector
+            auth_tag: Authentication tag
+            aad: Additional authenticated data
+        
+        Returns:
+            Decrypted plaintext as bytes
+        """
+        # Create cipher
+        cipher = Cipher(
+            algorithms.AES(session_key),
+            modes.GCM(iv, auth_tag),
+            backend=default_backend()
+        )
+        decryptor = cipher.decryptor()
+        
+        # Set AAD
+        decryptor.authenticate_additional_data(aad)
+        
+        # Decrypt
+        plaintext = decryptor.update(ciphertext) + decryptor.finalize()
+        
+        return plaintext
+    
+    def serialize_packet(self, packet: Dict[str, bytes]) -> Dict[str, str]:
+        """
+        Serialize encrypted packet for storage.
+        
+        Args:
+            packet: Encrypted packet data with bytes values
+        
+        Returns:
+            Serialized packet with base64-encoded strings
+        """
+        return {
+            'ciphertext': base64.b64encode(packet['ciphertext']).decode('utf-8'),
+            'iv': base64.b64encode(packet['iv']).decode('utf-8'),
+            'authTag': base64.b64encode(packet['authTag']).decode('utf-8'),
+            'aad': base64.b64encode(packet['aad']).decode('utf-8')
+        }
+    
+    def deserialize_packet(self, serialized: Dict[str, str]) -> Dict[str, bytes]:
+        """
+        Deserialize encrypted packet from storage.
+        
+        Args:
+            serialized: Serialized packet with base64-encoded strings
+        
+        Returns:
+            Packet with bytes values
+        """
+        return {
+            'ciphertext': base64.b64decode(serialized['ciphertext']),
+            'iv': base64.b64decode(serialized['iv']),
+            'authTag': base64.b64decode(serialized['authTag']),
+            'aad': base64.b64decode(serialized['aad'])
+        }
+    
+    def parse_aad(self, aad: bytes) -> Dict[str, Any]:
+        """
+        Parse AAD to extract metadata.
+        
+        Args:
+            aad: Additional authenticated data
+        
+        Returns:
+            Metadata dictionary
+        """
+        return json.loads(aad.decode())
+    
+    def is_valid_key_id(self, kid: str) -> bool:
+        """
+        Validate key ID format.
+        
+        Args:
+            kid: Key ID to validate
+        
+        Returns:
+            True if valid, False otherwise
+        """
+        import re
+        return bool(re.match(r'^[a-f0-9]{16}$', kid))
+    
+    def generate_session_id(self) -> str:
+        """
+        Generate session ID.
+        
+        Returns:
+            Unique session identifier
+        """
+        return os.urandom(16).hex()
+
+
+# Import time module for timestamp
+import time

--- a/python/src/indexedcp/keystores/__init__.py
+++ b/python/src/indexedcp/keystores/__init__.py
@@ -1,0 +1,48 @@
+"""
+KeyStore Factory and Exports
+
+Provides easy access to all keystore implementations.
+"""
+
+from typing import Dict, Any, Optional
+
+from .base_keystore import BaseKeyStore
+from .filesystem_keystore import FileSystemKeyStore
+
+
+def create_keystore(keystore_type: str, options: Optional[Dict[str, Any]] = None) -> BaseKeyStore:
+    """
+    Create a keystore instance based on type.
+    
+    Args:
+        keystore_type: Type of keystore ('filesystem', 'file', 'fs')
+        options: Configuration options for the keystore
+    
+    Returns:
+        Keystore instance
+    
+    Raises:
+        ValueError: If keystore type is unknown
+    
+    Examples:
+        >>> keystore = create_keystore('filesystem', {'key_store_path': './keys'})
+        >>> await keystore.initialize()
+    """
+    options = options or {}
+    keystore_type_lower = keystore_type.lower()
+    
+    if keystore_type_lower in ('filesystem', 'file', 'fs'):
+        return FileSystemKeyStore(options)
+    else:
+        valid_types = ['filesystem', 'file', 'fs']
+        raise ValueError(
+            f"Unknown keystore type: {keystore_type}. "
+            f"Valid types: {', '.join(valid_types)}"
+        )
+
+
+__all__ = [
+    'BaseKeyStore',
+    'FileSystemKeyStore',
+    'create_keystore'
+]

--- a/python/src/indexedcp/keystores/base_keystore.py
+++ b/python/src/indexedcp/keystores/base_keystore.py
@@ -1,0 +1,135 @@
+"""
+Base KeyStore interface
+
+All keystore implementations must extend this class and implement:
+- save(kid, key_data)
+- load(kid)
+- load_all()
+- delete(kid)
+- exists(kid)
+"""
+
+from abc import ABC, abstractmethod
+from typing import Optional, Dict, Any, List
+
+from ..logger import create_logger
+
+
+class BaseKeyStore(ABC):
+    """Abstract base class for keystore implementations."""
+    
+    def __init__(self, options: Optional[Dict[str, Any]] = None):
+        """
+        Initialize base keystore.
+        
+        Args:
+            options: Configuration options including log_level
+        """
+        options = options or {}
+        self.logger = create_logger(
+            name=self.__class__.__name__,
+            level=options.get('log_level', 'INFO')
+        )
+    
+    @abstractmethod
+    async def save(self, kid: str, key_data: Dict[str, Any]) -> None:
+        """
+        Save a key pair to storage.
+        
+        Args:
+            kid: Key ID
+            key_data: Key data to store
+                - kid: Key ID
+                - privateKey: Private key (PEM format)
+                - publicKey: Public key (PEM format)
+                - createdAt: Timestamp (milliseconds)
+                - active: Whether this is the active key
+        
+        Raises:
+            Exception: If save operation fails
+        """
+        pass
+    
+    @abstractmethod
+    async def load(self, kid: str) -> Optional[Dict[str, Any]]:
+        """
+        Load a specific key by ID.
+        
+        Args:
+            kid: Key ID
+        
+        Returns:
+            Key data dictionary or None if not found
+        
+        Raises:
+            Exception: If load operation fails
+        """
+        pass
+    
+    @abstractmethod
+    async def load_all(self) -> List[Dict[str, Any]]:
+        """
+        Load all keys from storage.
+        
+        Returns:
+            List of key data dictionaries
+        
+        Raises:
+            Exception: If load operation fails
+        """
+        pass
+    
+    @abstractmethod
+    async def delete(self, kid: str) -> bool:
+        """
+        Delete a key from storage.
+        
+        Args:
+            kid: Key ID
+        
+        Returns:
+            True if deleted, False if not found
+        
+        Raises:
+            Exception: If delete operation fails
+        """
+        pass
+    
+    @abstractmethod
+    async def exists(self, kid: str) -> bool:
+        """
+        Check if a key exists.
+        
+        Args:
+            kid: Key ID
+        
+        Returns:
+            True if key exists, False otherwise
+        """
+        pass
+    
+    async def list(self) -> List[str]:
+        """
+        List all key IDs.
+        
+        Returns:
+            List of key IDs
+        """
+        keys = await self.load_all()
+        return [k['kid'] for k in keys]
+    
+    async def close(self) -> None:
+        """
+        Clean up resources (optional).
+        
+        Override in subclass if cleanup is needed.
+        """
+        pass
+    
+    async def initialize(self) -> None:
+        """
+        Initialize the keystore (optional).
+        
+        Override in subclass if initialization is needed.
+        """
+        pass

--- a/python/src/indexedcp/keystores/filesystem_keystore.py
+++ b/python/src/indexedcp/keystores/filesystem_keystore.py
@@ -1,0 +1,201 @@
+"""
+Filesystem-based KeyStore implementation
+
+Stores keys as JSON files in a directory.
+Default implementation - no external dependencies.
+"""
+
+import os
+import json
+import stat
+from pathlib import Path
+from typing import Optional, Dict, Any, List
+import fcntl  # For file locking
+
+from .base_keystore import BaseKeyStore
+
+
+class FileSystemKeyStore(BaseKeyStore):
+    """Filesystem-based keystore that stores keys as JSON files."""
+    
+    def __init__(self, options: Optional[Dict[str, Any]] = None):
+        """
+        Initialize filesystem keystore.
+        
+        Args:
+            options: Configuration options
+                - key_store_path: Directory for key storage (default: './server-keys')
+                - log_level: Logging level
+        """
+        super().__init__(options)
+        options = options or {}
+        self.key_store_path = Path(options.get('key_store_path', './server-keys'))
+        self.file_extension = '.json'
+    
+    async def initialize(self) -> None:
+        """Initialize the keystore by creating the directory."""
+        try:
+            self.key_store_path.mkdir(parents=True, exist_ok=True)
+            # Set directory permissions to 0700 (owner read/write/execute only)
+            os.chmod(self.key_store_path, stat.S_IRWXU)
+            self.logger.info(f'✓ Filesystem keystore initialized: {self.key_store_path}')
+        except Exception as error:
+            self.logger.error(f'Failed to initialize filesystem keystore: {error}')
+            raise
+    
+    async def save(self, kid: str, key_data: Dict[str, Any]) -> None:
+        """
+        Save a key pair to filesystem.
+        
+        Args:
+            kid: Key ID
+            key_data: Key data to store
+        
+        Raises:
+            Exception: If save operation fails
+        """
+        try:
+            key_file = self.key_store_path / f'{kid}{self.file_extension}'
+            
+            # Write with file locking for thread safety
+            with open(key_file, 'w', encoding='utf-8') as f:
+                # Acquire exclusive lock
+                fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+                try:
+                    json.dump(key_data, f, indent=2)
+                finally:
+                    # Release lock
+                    fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+            
+            # Set file permissions to 0600 (owner read/write only)
+            os.chmod(key_file, stat.S_IRUSR | stat.S_IWUSR)
+            
+            self.logger.info(f'🔑 Persisted key to filesystem: {kid}')
+        except Exception as error:
+            self.logger.error(f'Failed to save key {kid}: {error}')
+            raise
+    
+    async def load(self, kid: str) -> Optional[Dict[str, Any]]:
+        """
+        Load a specific key by ID.
+        
+        Args:
+            kid: Key ID
+        
+        Returns:
+            Key data or None if not found
+        """
+        try:
+            key_file = self.key_store_path / f'{kid}{self.file_extension}'
+            
+            if not key_file.exists():
+                return None
+            
+            # Read with file locking
+            with open(key_file, 'r', encoding='utf-8') as f:
+                # Acquire shared lock
+                fcntl.flock(f.fileno(), fcntl.LOCK_SH)
+                try:
+                    data = json.load(f)
+                finally:
+                    # Release lock
+                    fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+            
+            return data
+        except FileNotFoundError:
+            return None
+        except Exception as error:
+            self.logger.error(f'Failed to load key {kid}: {error}')
+            raise
+    
+    async def load_all(self) -> List[Dict[str, Any]]:
+        """
+        Load all keys from filesystem.
+        
+        Returns:
+            List of key data dictionaries
+        """
+        try:
+            # Ensure directory exists
+            self.key_store_path.mkdir(parents=True, exist_ok=True)
+            
+            keys = []
+            for file_path in self.key_store_path.glob(f'*{self.file_extension}'):
+                try:
+                    with open(file_path, 'r', encoding='utf-8') as f:
+                        # Acquire shared lock
+                        fcntl.flock(f.fileno(), fcntl.LOCK_SH)
+                        try:
+                            data = json.load(f)
+                            keys.append(data)
+                        finally:
+                            # Release lock
+                            fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+                except Exception as error:
+                    self.logger.warning(f'Failed to load key file {file_path.name}: {error}')
+                    # Continue loading other keys
+            
+            return keys
+        except Exception as error:
+            self.logger.error(f'Failed to load all keys: {error}')
+            return []
+    
+    async def delete(self, kid: str) -> bool:
+        """
+        Delete a key from filesystem.
+        
+        Args:
+            kid: Key ID
+        
+        Returns:
+            True if deleted, False if not found
+        """
+        try:
+            key_file = self.key_store_path / f'{kid}{self.file_extension}'
+            
+            if not key_file.exists():
+                return False
+            
+            key_file.unlink()
+            self.logger.info(f'🗑️  Deleted key from filesystem: {kid}')
+            return True
+        except FileNotFoundError:
+            return False
+        except Exception as error:
+            self.logger.error(f'Failed to delete key {kid}: {error}')
+            raise
+    
+    async def exists(self, kid: str) -> bool:
+        """
+        Check if a key exists in filesystem.
+        
+        Args:
+            kid: Key ID
+        
+        Returns:
+            True if key exists, False otherwise
+        """
+        try:
+            key_file = self.key_store_path / f'{kid}{self.file_extension}'
+            return key_file.exists()
+        except Exception:
+            return False
+    
+    async def list(self) -> List[str]:
+        """
+        List all key IDs in filesystem.
+        
+        Returns:
+            List of key IDs
+        """
+        try:
+            return [
+                f.stem  # Get filename without extension
+                for f in self.key_store_path.glob(f'*{self.file_extension}')
+            ]
+        except Exception:
+            return []
+    
+    async def close(self) -> None:
+        """Clean up resources (no-op for filesystem)."""
+        pass

--- a/python/tests/test_crypto.py
+++ b/python/tests/test_crypto.py
@@ -1,0 +1,465 @@
+"""
+Comprehensive tests for crypto_utils module
+"""
+
+import os
+import pytest
+import json
+from cryptography.exceptions import InvalidTag
+
+from indexedcp.crypto_utils import CryptoUtils
+
+
+class TestCryptoUtils:
+    """Test suite for CryptoUtils class"""
+    
+    @pytest.fixture
+    def crypto(self):
+        """Create CryptoUtils instance for testing"""
+        return CryptoUtils()
+    
+    @pytest.fixture
+    def key_pair(self, crypto):
+        """Generate RSA key pair for testing"""
+        return crypto.generate_server_key_pair()
+    
+    @pytest.fixture
+    def session_key(self, crypto):
+        """Generate AES session key for testing"""
+        return crypto.generate_session_key()
+    
+    def test_generate_server_key_pair(self, crypto):
+        """Test RSA-4096 key pair generation"""
+        key_pair = crypto.generate_server_key_pair()
+        
+        # Check structure
+        assert 'publicKey' in key_pair
+        assert 'privateKey' in key_pair
+        assert 'kid' in key_pair
+        
+        # Check PEM format
+        assert key_pair['publicKey'].startswith('-----BEGIN PUBLIC KEY-----')
+        assert key_pair['privateKey'].startswith('-----BEGIN PRIVATE KEY-----')
+        
+        # Check key ID format (16 hex characters)
+        assert len(key_pair['kid']) == 16
+        assert all(c in '0123456789abcdef' for c in key_pair['kid'])
+    
+    def test_generate_server_key_pair_custom_size(self, crypto):
+        """Test RSA key pair generation with custom modulus length"""
+        key_pair = crypto.generate_server_key_pair(modulus_length=2048)
+        
+        assert 'publicKey' in key_pair
+        assert 'privateKey' in key_pair
+        assert 'kid' in key_pair
+    
+    def test_generate_session_key(self, crypto):
+        """Test AES-256 session key generation"""
+        session_key = crypto.generate_session_key()
+        
+        # Check length (256 bits = 32 bytes)
+        assert len(session_key) == 32
+        assert isinstance(session_key, bytes)
+    
+    def test_session_keys_are_unique(self, crypto):
+        """Test that generated session keys are unique"""
+        key1 = crypto.generate_session_key()
+        key2 = crypto.generate_session_key()
+        
+        assert key1 != key2
+    
+    def test_wrap_and_unwrap_session_key(self, crypto, key_pair, session_key):
+        """Test RSA-OAEP key wrapping and unwrapping"""
+        # Wrap session key with public key
+        wrapped_key = crypto.wrap_session_key(
+            session_key, 
+            key_pair['publicKey']
+        )
+        
+        # Check wrapped key is bytes
+        assert isinstance(wrapped_key, bytes)
+        assert len(wrapped_key) > 0
+        
+        # Unwrap session key with private key
+        unwrapped_key = crypto.unwrap_session_key(
+            wrapped_key,
+            key_pair['privateKey']
+        )
+        
+        # Check unwrapped key matches original
+        assert unwrapped_key == session_key
+    
+    def test_wrapped_keys_are_different(self, crypto, key_pair):
+        """Test that wrapping the same key produces different results (due to OAEP padding)"""
+        session_key = crypto.generate_session_key()
+        
+        wrapped1 = crypto.wrap_session_key(session_key, key_pair['publicKey'])
+        wrapped2 = crypto.wrap_session_key(session_key, key_pair['publicKey'])
+        
+        # OAEP padding includes randomness, so ciphertexts differ
+        assert wrapped1 != wrapped2
+    
+    def test_encrypt_and_decrypt_packet(self, crypto, session_key):
+        """Test AES-256-GCM packet encryption and decryption"""
+        # Test data
+        plaintext = b"Hello, this is a test message!"
+        metadata = {
+            'sessionId': 'test-session-123',
+            'seq': 1,
+            'codec': 'raw',
+            'timestamp': 1699999999999
+        }
+        
+        # Encrypt packet
+        encrypted = crypto.encrypt_packet(plaintext, session_key, metadata)
+        
+        # Check structure
+        assert 'ciphertext' in encrypted
+        assert 'iv' in encrypted
+        assert 'authTag' in encrypted
+        assert 'aad' in encrypted
+        
+        # Check types
+        assert isinstance(encrypted['ciphertext'], bytes)
+        assert isinstance(encrypted['iv'], bytes)
+        assert isinstance(encrypted['authTag'], bytes)
+        assert isinstance(encrypted['aad'], bytes)
+        
+        # Check lengths
+        assert len(encrypted['iv']) == 12  # 96 bits
+        assert len(encrypted['authTag']) == 16  # 128 bits
+        
+        # Decrypt packet
+        decrypted = crypto.decrypt_packet(
+            encrypted['ciphertext'],
+            session_key,
+            encrypted['iv'],
+            encrypted['authTag'],
+            encrypted['aad']
+        )
+        
+        # Check decrypted matches original
+        assert decrypted == plaintext
+    
+    def test_encrypt_produces_unique_ivs(self, crypto, session_key):
+        """Test that each encryption uses a unique IV"""
+        plaintext = b"Test data"
+        metadata = {'sessionId': 'test', 'seq': 1}
+        
+        encrypted1 = crypto.encrypt_packet(plaintext, session_key, metadata)
+        encrypted2 = crypto.encrypt_packet(plaintext, session_key, metadata)
+        
+        # IVs should be different
+        assert encrypted1['iv'] != encrypted2['iv']
+        
+        # Ciphertexts should be different (due to different IVs)
+        assert encrypted1['ciphertext'] != encrypted2['ciphertext']
+    
+    def test_decrypt_with_wrong_key_fails(self, crypto):
+        """Test that decryption fails with wrong session key"""
+        plaintext = b"Secret data"
+        metadata = {'sessionId': 'test', 'seq': 1}
+        
+        # Encrypt with one key
+        session_key1 = crypto.generate_session_key()
+        encrypted = crypto.encrypt_packet(plaintext, session_key1, metadata)
+        
+        # Try to decrypt with different key
+        session_key2 = crypto.generate_session_key()
+        
+        with pytest.raises(InvalidTag):
+            crypto.decrypt_packet(
+                encrypted['ciphertext'],
+                session_key2,
+                encrypted['iv'],
+                encrypted['authTag'],
+                encrypted['aad']
+            )
+    
+    def test_decrypt_with_tampered_ciphertext_fails(self, crypto, session_key):
+        """Test that decryption fails if ciphertext is tampered"""
+        plaintext = b"Important data"
+        metadata = {'sessionId': 'test', 'seq': 1}
+        
+        encrypted = crypto.encrypt_packet(plaintext, session_key, metadata)
+        
+        # Tamper with ciphertext
+        tampered_ciphertext = bytearray(encrypted['ciphertext'])
+        tampered_ciphertext[0] ^= 0xFF  # Flip bits in first byte
+        
+        with pytest.raises(InvalidTag):
+            crypto.decrypt_packet(
+                bytes(tampered_ciphertext),
+                session_key,
+                encrypted['iv'],
+                encrypted['authTag'],
+                encrypted['aad']
+            )
+    
+    def test_decrypt_with_tampered_aad_fails(self, crypto, session_key):
+        """Test that decryption fails if AAD is tampered"""
+        plaintext = b"Critical data"
+        metadata = {'sessionId': 'test', 'seq': 1}
+        
+        encrypted = crypto.encrypt_packet(plaintext, session_key, metadata)
+        
+        # Tamper with AAD
+        tampered_aad = b'{"sessionId":"test","seq":999,"codec":"raw","timestamp":1699999999999}'
+        
+        with pytest.raises(InvalidTag):
+            crypto.decrypt_packet(
+                encrypted['ciphertext'],
+                session_key,
+                encrypted['iv'],
+                encrypted['authTag'],
+                tampered_aad
+            )
+    
+    def test_serialize_and_deserialize_packet(self, crypto, session_key):
+        """Test packet serialization for storage"""
+        plaintext = b"Test data for serialization"
+        metadata = {'sessionId': 'test', 'seq': 1}
+        
+        # Encrypt packet
+        encrypted = crypto.encrypt_packet(plaintext, session_key, metadata)
+        
+        # Serialize
+        serialized = crypto.serialize_packet(encrypted)
+        
+        # Check serialized types (all strings)
+        assert isinstance(serialized['ciphertext'], str)
+        assert isinstance(serialized['iv'], str)
+        assert isinstance(serialized['authTag'], str)
+        assert isinstance(serialized['aad'], str)
+        
+        # Deserialize
+        deserialized = crypto.deserialize_packet(serialized)
+        
+        # Check deserialized matches original
+        assert deserialized['ciphertext'] == encrypted['ciphertext']
+        assert deserialized['iv'] == encrypted['iv']
+        assert deserialized['authTag'] == encrypted['authTag']
+        assert deserialized['aad'] == encrypted['aad']
+        
+        # Decrypt deserialized packet
+        decrypted = crypto.decrypt_packet(
+            deserialized['ciphertext'],
+            session_key,
+            deserialized['iv'],
+            deserialized['authTag'],
+            deserialized['aad']
+        )
+        
+        assert decrypted == plaintext
+    
+    def test_parse_aad(self, crypto):
+        """Test AAD parsing"""
+        metadata = {
+            'sessionId': 'test-session',
+            'seq': 42,
+            'codec': 'gzip',
+            'timestamp': 1699999999999
+        }
+        
+        aad = json.dumps(metadata, separators=(',', ':')).encode()
+        parsed = crypto.parse_aad(aad)
+        
+        assert parsed['sessionId'] == 'test-session'
+        assert parsed['seq'] == 42
+        assert parsed['codec'] == 'gzip'
+        assert parsed['timestamp'] == 1699999999999
+    
+    def test_is_valid_key_id(self, crypto):
+        """Test key ID validation"""
+        # Valid key IDs (16 hex characters)
+        assert crypto.is_valid_key_id('0123456789abcdef')
+        assert crypto.is_valid_key_id('fedcba9876543210')
+        assert crypto.is_valid_key_id('a1b2c3d4e5f60718')
+        
+        # Invalid key IDs
+        assert not crypto.is_valid_key_id('0123456789ABCDEF')  # Uppercase
+        assert not crypto.is_valid_key_id('0123456789abcde')   # Too short
+        assert not crypto.is_valid_key_id('0123456789abcdef0') # Too long
+        assert not crypto.is_valid_key_id('xyz123456789abcd')  # Invalid chars
+        assert not crypto.is_valid_key_id('')                   # Empty
+    
+    def test_generate_session_id(self, crypto):
+        """Test session ID generation"""
+        session_id = crypto.generate_session_id()
+        
+        # Check format (32 hex characters)
+        assert len(session_id) == 32
+        assert all(c in '0123456789abcdef' for c in session_id)
+        
+        # Check uniqueness
+        session_id2 = crypto.generate_session_id()
+        assert session_id != session_id2
+    
+    def test_large_data_encryption(self, crypto, session_key):
+        """Test encryption of large data (1MB)"""
+        # Generate 1MB of random data
+        large_data = os.urandom(1024 * 1024)
+        metadata = {'sessionId': 'test', 'seq': 1}
+        
+        # Encrypt
+        encrypted = crypto.encrypt_packet(large_data, session_key, metadata)
+        
+        # Decrypt
+        decrypted = crypto.decrypt_packet(
+            encrypted['ciphertext'],
+            session_key,
+            encrypted['iv'],
+            encrypted['authTag'],
+            encrypted['aad']
+        )
+        
+        assert decrypted == large_data
+    
+    def test_empty_data_encryption(self, crypto, session_key):
+        """Test encryption of empty data"""
+        plaintext = b""
+        metadata = {'sessionId': 'test', 'seq': 1}
+        
+        encrypted = crypto.encrypt_packet(plaintext, session_key, metadata)
+        decrypted = crypto.decrypt_packet(
+            encrypted['ciphertext'],
+            session_key,
+            encrypted['iv'],
+            encrypted['authTag'],
+            encrypted['aad']
+        )
+        
+        assert decrypted == plaintext
+    
+    def test_class_instantiation(self):
+        """Test that CryptoUtils can be instantiated multiple times"""
+        crypto1 = CryptoUtils()
+        crypto2 = CryptoUtils()
+        
+        # Each instance should work independently
+        key_pair = crypto1.generate_server_key_pair()
+        assert 'kid' in key_pair
+        
+        session_key = crypto2.generate_session_key()
+        assert len(session_key) == 32
+
+
+class TestEndToEndEncryption:
+    """End-to-end encryption workflow tests"""
+    
+    def test_full_encryption_workflow(self):
+        """Test complete encryption workflow from key generation to decryption"""
+        crypto = CryptoUtils()
+        
+        # 1. Server generates RSA key pair
+        server_keys = crypto.generate_server_key_pair()
+        
+        # 2. Client generates ephemeral AES session key
+        session_key = crypto.generate_session_key()
+        
+        # 3. Client wraps session key with server's public key
+        wrapped_key = crypto.wrap_session_key(
+            session_key,
+            server_keys['publicKey']
+        )
+        
+        # 4. Client encrypts data
+        plaintext = b"Sensitive file data"
+        metadata = {
+            'sessionId': crypto.generate_session_id(),
+            'seq': 1,
+            'codec': 'raw'
+        }
+        encrypted_packet = crypto.encrypt_packet(plaintext, session_key, metadata)
+        
+        # 5. Serialize for storage/transmission
+        serialized = crypto.serialize_packet(encrypted_packet)
+        
+        # Simulate storage/network transmission
+        # In real scenario, client would store serialized packet + wrapped_key
+        
+        # 6. Server unwraps session key
+        unwrapped_key = crypto.unwrap_session_key(
+            wrapped_key,
+            server_keys['privateKey']
+        )
+        
+        # 7. Server deserializes packet
+        deserialized = crypto.deserialize_packet(serialized)
+        
+        # 8. Server decrypts data
+        decrypted = crypto.decrypt_packet(
+            deserialized['ciphertext'],
+            unwrapped_key,
+            deserialized['iv'],
+            deserialized['authTag'],
+            deserialized['aad']
+        )
+        
+        # 9. Verify plaintext matches original
+        assert decrypted == plaintext
+    
+    def test_multiple_packets_same_session(self):
+        """Test encrypting multiple packets with same session key"""
+        crypto = CryptoUtils()
+        
+        session_key = crypto.generate_session_key()
+        session_id = crypto.generate_session_id()
+        
+        packets_plaintext = [
+            b"Packet 1 data",
+            b"Packet 2 data",
+            b"Packet 3 data"
+        ]
+        
+        # Encrypt all packets
+        encrypted_packets = []
+        for seq, plaintext in enumerate(packets_plaintext):
+            metadata = {
+                'sessionId': session_id,
+                'seq': seq,
+                'codec': 'raw'
+            }
+            encrypted = crypto.encrypt_packet(plaintext, session_key, metadata)
+            encrypted_packets.append(encrypted)
+        
+        # Decrypt all packets
+        for seq, encrypted in enumerate(encrypted_packets):
+            decrypted = crypto.decrypt_packet(
+                encrypted['ciphertext'],
+                session_key,
+                encrypted['iv'],
+                encrypted['authTag'],
+                encrypted['aad']
+            )
+            assert decrypted == packets_plaintext[seq]
+    
+    def test_key_rotation_scenario(self):
+        """Test scenario where server rotates keys but old keys still work"""
+        crypto = CryptoUtils()
+        
+        # Old key pair
+        old_keys = crypto.generate_server_key_pair()
+        
+        # Client encrypts with old public key
+        session_key = crypto.generate_session_key()
+        wrapped_key = crypto.wrap_session_key(session_key, old_keys['publicKey'])
+        
+        plaintext = b"Data encrypted with old key"
+        metadata = {'sessionId': crypto.generate_session_id(), 'seq': 1}
+        encrypted = crypto.encrypt_packet(plaintext, session_key, metadata)
+        
+        # Server rotates to new key pair (but keeps old private key)
+        new_keys = crypto.generate_server_key_pair()
+        
+        # Server can still decrypt old data with old private key
+        unwrapped_key = crypto.unwrap_session_key(wrapped_key, old_keys['privateKey'])
+        decrypted = crypto.decrypt_packet(
+            encrypted['ciphertext'],
+            unwrapped_key,
+            encrypted['iv'],
+            encrypted['authTag'],
+            encrypted['aad']
+        )
+        
+        assert decrypted == plaintext

--- a/python/tests/test_keystore.py
+++ b/python/tests/test_keystore.py
@@ -1,0 +1,435 @@
+"""
+Comprehensive tests for keystore implementations
+"""
+
+import os
+import json
+import stat
+import pytest
+import tempfile
+import shutil
+from pathlib import Path
+
+from indexedcp.keystores import (
+    BaseKeyStore,
+    FileSystemKeyStore,
+    create_keystore
+)
+from indexedcp import CryptoUtils
+
+
+class TestBaseKeyStore:
+    """Test BaseKeyStore abstract class"""
+    
+    def test_cannot_instantiate_directly(self):
+        """Test that BaseKeyStore cannot be instantiated directly"""
+        with pytest.raises(TypeError):
+            BaseKeyStore()
+    
+    def test_abstract_methods_must_be_implemented(self):
+        """Test that subclasses must implement abstract methods"""
+        
+        class IncompleteKeyStore(BaseKeyStore):
+            pass
+        
+        with pytest.raises(TypeError):
+            IncompleteKeyStore()
+
+
+class TestFileSystemKeyStore:
+    """Test FileSystemKeyStore implementation"""
+    
+    @pytest.fixture
+    async def temp_keystore_dir(self):
+        """Create temporary directory for keystore tests"""
+        temp_dir = tempfile.mkdtemp(prefix='test_keystore_')
+        yield temp_dir
+        # Cleanup
+        shutil.rmtree(temp_dir, ignore_errors=True)
+    
+    @pytest.fixture
+    async def keystore(self, temp_keystore_dir):
+        """Create filesystem keystore instance"""
+        ks = FileSystemKeyStore({'key_store_path': temp_keystore_dir})
+        await ks.initialize()
+        yield ks
+        await ks.close()
+    
+    @pytest.fixture
+    def sample_key_data(self):
+        """Generate sample key data for testing"""
+        crypto = CryptoUtils()
+        key_pair = crypto.generate_server_key_pair()
+        return {
+            'kid': key_pair['kid'],
+            'publicKey': key_pair['publicKey'],
+            'privateKey': key_pair['privateKey'],
+            'createdAt': 1699999999999,
+            'active': True
+        }
+    
+    @pytest.mark.asyncio
+    async def test_initialize_creates_directory(self, temp_keystore_dir):
+        """Test that initialize creates the keystore directory"""
+        keystore = FileSystemKeyStore({'key_store_path': temp_keystore_dir})
+        await keystore.initialize()
+        
+        assert Path(temp_keystore_dir).exists()
+        assert Path(temp_keystore_dir).is_dir()
+        
+        # Check directory permissions (0700)
+        dir_stat = os.stat(temp_keystore_dir)
+        dir_mode = stat.S_IMODE(dir_stat.st_mode)
+        assert dir_mode == stat.S_IRWXU  # 0700
+    
+    @pytest.mark.asyncio
+    async def test_save_and_load(self, keystore, sample_key_data):
+        """Test saving and loading a key"""
+        # Save key
+        await keystore.save(sample_key_data['kid'], sample_key_data)
+        
+        # Load key
+        loaded = await keystore.load(sample_key_data['kid'])
+        
+        assert loaded is not None
+        assert loaded['kid'] == sample_key_data['kid']
+        assert loaded['publicKey'] == sample_key_data['publicKey']
+        assert loaded['privateKey'] == sample_key_data['privateKey']
+        assert loaded['createdAt'] == sample_key_data['createdAt']
+        assert loaded['active'] == sample_key_data['active']
+    
+    @pytest.mark.asyncio
+    async def test_save_sets_file_permissions(self, keystore, sample_key_data, temp_keystore_dir):
+        """Test that saved key files have correct permissions (0600)"""
+        await keystore.save(sample_key_data['kid'], sample_key_data)
+        
+        key_file = Path(temp_keystore_dir) / f"{sample_key_data['kid']}.json"
+        file_stat = os.stat(key_file)
+        file_mode = stat.S_IMODE(file_stat.st_mode)
+        
+        # Check file permissions (0600 - owner read/write only)
+        assert file_mode == (stat.S_IRUSR | stat.S_IWUSR)  # 0600
+    
+    @pytest.mark.asyncio
+    async def test_load_nonexistent_returns_none(self, keystore):
+        """Test that loading non-existent key returns None"""
+        loaded = await keystore.load('non-existent-kid')
+        assert loaded is None
+    
+    @pytest.mark.asyncio
+    async def test_exists(self, keystore, sample_key_data):
+        """Test key existence check"""
+        # Key doesn't exist yet
+        assert await keystore.exists(sample_key_data['kid']) is False
+        
+        # Save key
+        await keystore.save(sample_key_data['kid'], sample_key_data)
+        
+        # Key now exists
+        assert await keystore.exists(sample_key_data['kid']) is True
+    
+    @pytest.mark.asyncio
+    async def test_delete(self, keystore, sample_key_data):
+        """Test deleting a key"""
+        # Save key
+        await keystore.save(sample_key_data['kid'], sample_key_data)
+        assert await keystore.exists(sample_key_data['kid']) is True
+        
+        # Delete key
+        result = await keystore.delete(sample_key_data['kid'])
+        assert result is True
+        
+        # Key no longer exists
+        assert await keystore.exists(sample_key_data['kid']) is False
+    
+    @pytest.mark.asyncio
+    async def test_delete_nonexistent_returns_false(self, keystore):
+        """Test that deleting non-existent key returns False"""
+        result = await keystore.delete('non-existent-kid')
+        assert result is False
+    
+    @pytest.mark.asyncio
+    async def test_list(self, keystore):
+        """Test listing key IDs"""
+        # Create multiple keys
+        crypto = CryptoUtils()
+        keys = []
+        for _ in range(3):
+            kp = crypto.generate_server_key_pair()
+            key_data = {
+                'kid': kp['kid'],
+                'publicKey': kp['publicKey'],
+                'privateKey': kp['privateKey'],
+                'createdAt': 1699999999999,
+                'active': False
+            }
+            keys.append(key_data)
+            await keystore.save(key_data['kid'], key_data)
+        
+        # List keys
+        key_list = await keystore.list()
+        
+        assert len(key_list) == 3
+        for key_data in keys:
+            assert key_data['kid'] in key_list
+    
+    @pytest.mark.asyncio
+    async def test_load_all(self, keystore):
+        """Test loading all keys"""
+        # Create multiple keys
+        crypto = CryptoUtils()
+        keys = []
+        for _ in range(3):
+            kp = crypto.generate_server_key_pair()
+            key_data = {
+                'kid': kp['kid'],
+                'publicKey': kp['publicKey'],
+                'privateKey': kp['privateKey'],
+                'createdAt': 1699999999999,
+                'active': False
+            }
+            keys.append(key_data)
+            await keystore.save(key_data['kid'], key_data)
+        
+        # Load all keys
+        all_keys = await keystore.load_all()
+        
+        assert len(all_keys) == 3
+        loaded_kids = {k['kid'] for k in all_keys}
+        expected_kids = {k['kid'] for k in keys}
+        assert loaded_kids == expected_kids
+    
+    @pytest.mark.asyncio
+    async def test_load_all_empty_directory(self, keystore):
+        """Test loading all keys from empty directory"""
+        all_keys = await keystore.load_all()
+        assert all_keys == []
+    
+    @pytest.mark.asyncio
+    async def test_json_format(self, keystore, sample_key_data, temp_keystore_dir):
+        """Test that keys are stored in proper JSON format"""
+        await keystore.save(sample_key_data['kid'], sample_key_data)
+        
+        # Read file directly
+        key_file = Path(temp_keystore_dir) / f"{sample_key_data['kid']}.json"
+        with open(key_file, 'r') as f:
+            data = json.load(f)
+        
+        assert data == sample_key_data
+    
+    @pytest.mark.asyncio
+    async def test_file_locking_concurrent_writes(self, keystore, sample_key_data):
+        """Test that file locking works for concurrent operations"""
+        import asyncio
+        
+        # Attempt concurrent saves (file locking should handle this)
+        async def save_operation(kid_suffix):
+            key_data = sample_key_data.copy()
+            key_data['kid'] = f"{sample_key_data['kid']}_{kid_suffix}"
+            await keystore.save(key_data['kid'], key_data)
+        
+        # Run concurrent saves
+        await asyncio.gather(
+            save_operation('1'),
+            save_operation('2'),
+            save_operation('3')
+        )
+        
+        # Verify all keys were saved
+        all_keys = await keystore.load_all()
+        assert len(all_keys) == 3
+    
+    @pytest.mark.asyncio
+    async def test_persistence_across_instances(self, temp_keystore_dir, sample_key_data):
+        """Test that keys persist across keystore instances"""
+        # Create first instance and save key
+        keystore1 = FileSystemKeyStore({'key_store_path': temp_keystore_dir})
+        await keystore1.initialize()
+        await keystore1.save(sample_key_data['kid'], sample_key_data)
+        await keystore1.close()
+        
+        # Create second instance and load key
+        keystore2 = FileSystemKeyStore({'key_store_path': temp_keystore_dir})
+        await keystore2.initialize()
+        loaded = await keystore2.load(sample_key_data['kid'])
+        await keystore2.close()
+        
+        assert loaded is not None
+        assert loaded['kid'] == sample_key_data['kid']
+
+
+class TestKeystoreFactory:
+    """Test keystore factory function"""
+    
+    def test_create_filesystem_keystore(self):
+        """Test factory creates FileSystemKeyStore"""
+        keystore = create_keystore('filesystem', {'key_store_path': './test-keys'})
+        assert isinstance(keystore, FileSystemKeyStore)
+    
+    def test_create_filesystem_keystore_aliases(self):
+        """Test factory recognizes filesystem aliases"""
+        # Test all aliases
+        for alias in ['filesystem', 'file', 'fs']:
+            keystore = create_keystore(alias, {'key_store_path': './test-keys'})
+            assert isinstance(keystore, FileSystemKeyStore)
+    
+    def test_create_filesystem_keystore_case_insensitive(self):
+        """Test factory is case-insensitive"""
+        keystore = create_keystore('FileSystem', {'key_store_path': './test-keys'})
+        assert isinstance(keystore, FileSystemKeyStore)
+    
+    def test_factory_invalid_type_raises_error(self):
+        """Test factory raises error for invalid type"""
+        with pytest.raises(ValueError) as exc_info:
+            create_keystore('invalid-type')
+        
+        assert 'Unknown keystore type' in str(exc_info.value)
+        assert 'invalid-type' in str(exc_info.value)
+    
+    def test_factory_with_options(self):
+        """Test factory passes options to keystore"""
+        keystore = create_keystore('filesystem', {
+            'key_store_path': './custom-path',
+            'log_level': 'DEBUG'
+        })
+        assert isinstance(keystore, FileSystemKeyStore)
+        assert keystore.key_store_path == Path('./custom-path')
+
+
+class TestKeystoreIntegration:
+    """Integration tests for keystore with crypto operations"""
+    
+    @pytest.fixture
+    async def temp_dir(self):
+        """Create temporary directory"""
+        temp_dir = tempfile.mkdtemp(prefix='test_integration_')
+        yield temp_dir
+        shutil.rmtree(temp_dir, ignore_errors=True)
+    
+    @pytest.mark.asyncio
+    async def test_full_key_lifecycle(self, temp_dir):
+        """Test complete key lifecycle: generate, save, load, use, delete"""
+        # Create keystore
+        keystore = create_keystore('filesystem', {'key_store_path': temp_dir})
+        await keystore.initialize()
+        
+        # Generate key pair
+        crypto = CryptoUtils()
+        key_pair = crypto.generate_server_key_pair()
+        
+        # Save to keystore
+        key_data = {
+            'kid': key_pair['kid'],
+            'publicKey': key_pair['publicKey'],
+            'privateKey': key_pair['privateKey'],
+            'createdAt': 1699999999999,
+            'active': True
+        }
+        await keystore.save(key_data['kid'], key_data)
+        
+        # Load from keystore
+        loaded = await keystore.load(key_data['kid'])
+        assert loaded is not None
+        
+        # Use the loaded key for encryption/decryption
+        session_key = crypto.generate_session_key()
+        wrapped = crypto.wrap_session_key(session_key, loaded['publicKey'])
+        unwrapped = crypto.unwrap_session_key(wrapped, loaded['privateKey'])
+        assert session_key == unwrapped
+        
+        # Delete key
+        await keystore.delete(key_data['kid'])
+        assert await keystore.exists(key_data['kid']) is False
+        
+        await keystore.close()
+    
+    @pytest.mark.asyncio
+    async def test_key_rotation_scenario(self, temp_dir):
+        """Test key rotation: new key active, old key retained for decryption"""
+        keystore = create_keystore('filesystem', {'key_store_path': temp_dir})
+        await keystore.initialize()
+        
+        crypto = CryptoUtils()
+        
+        # Generate and save old key (initially active)
+        old_kp = crypto.generate_server_key_pair()
+        old_key = {
+            'kid': old_kp['kid'],
+            'publicKey': old_kp['publicKey'],
+            'privateKey': old_kp['privateKey'],
+            'createdAt': 1699999999999,
+            'active': True
+        }
+        await keystore.save(old_key['kid'], old_key)
+        
+        # Generate and save new key (now active)
+        new_kp = crypto.generate_server_key_pair()
+        new_key = {
+            'kid': new_kp['kid'],
+            'publicKey': new_kp['publicKey'],
+            'privateKey': new_kp['privateKey'],
+            'createdAt': 1700000000000,
+            'active': True
+        }
+        
+        # Deactivate old key
+        old_key['active'] = False
+        await keystore.save(old_key['kid'], old_key)
+        
+        # Save new key
+        await keystore.save(new_key['kid'], new_key)
+        
+        # Verify both keys exist
+        assert await keystore.exists(old_key['kid']) is True
+        assert await keystore.exists(new_key['kid']) is True
+        
+        # Load both keys
+        loaded_old = await keystore.load(old_key['kid'])
+        loaded_new = await keystore.load(new_key['kid'])
+        
+        assert loaded_old['active'] is False
+        assert loaded_new['active'] is True
+        
+        # Old key can still decrypt old data
+        session_key = crypto.generate_session_key()
+        wrapped_with_old = crypto.wrap_session_key(session_key, loaded_old['publicKey'])
+        unwrapped = crypto.unwrap_session_key(wrapped_with_old, loaded_old['privateKey'])
+        assert session_key == unwrapped
+        
+        await keystore.close()
+    
+    @pytest.mark.asyncio
+    async def test_multiple_active_keys(self, temp_dir):
+        """Test scenario with multiple keys for multi-server deployment"""
+        keystore = create_keystore('filesystem', {'key_store_path': temp_dir})
+        await keystore.initialize()
+        
+        crypto = CryptoUtils()
+        
+        # Create 3 keys (simulating 3 servers)
+        keys = []
+        for i in range(3):
+            kp = crypto.generate_server_key_pair()
+            key_data = {
+                'kid': kp['kid'],
+                'publicKey': kp['publicKey'],
+                'privateKey': kp['privateKey'],
+                'createdAt': 1699999999999 + i,
+                'active': True
+            }
+            keys.append(key_data)
+            await keystore.save(key_data['kid'], key_data)
+        
+        # Verify all keys stored
+        all_keys = await keystore.load_all()
+        assert len(all_keys) == 3
+        
+        # Each key should work independently
+        session_key = crypto.generate_session_key()
+        for key_data in keys:
+            loaded = await keystore.load(key_data['kid'])
+            wrapped = crypto.wrap_session_key(session_key, loaded['publicKey'])
+            unwrapped = crypto.unwrap_session_key(wrapped, loaded['privateKey'])
+            assert session_key == unwrapped
+        
+        await keystore.close()


### PR DESCRIPTION
- Implement RSA-4096 and AES-256-GCM encryption (crypto_utils.py)
- Add pluggable keystore abstraction with filesystem implementation
- Include 44 comprehensive tests (21 crypto + 23 keystore)
- Set secure file permissions (0600/0700) with thread-safe locking